### PR TITLE
Fixes TBS Responsive Nav & CSRF Token, Committed diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,1 @@
-<<<<<<< HEAD
-.gitattributes export-ignore  
-.gitignore export-ignore
-=======
 * text=auto
->>>>>>> 8709c6c6b062658eab23abf18aada550fb2efde9

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,5 @@
-<<<<<<< HEAD
-/vendor
-composer.phar
-composer.lock
-.DS_Store
-.idea/
-=======
 /bootstrap/compiled.php
 /vendor
 composer.phar
 composer.lock
 .DS_Store
->>>>>>> 8709c6c6b062658eab23abf18aada550fb2efde9

--- a/app/views/account/index.blade.php
+++ b/app/views/account/index.blade.php
@@ -20,6 +20,10 @@ body {
 	<h1>Edit your settings</h1>
 </div>
 <form method="post" action="" class="form-horizontal">
+
+	<!-- CSRF Token -->
+	{{ Form::token() }}
+
 	<!-- First Name -->
 	<div class="control-group {{{ $errors->has('first_name') ? 'error' : '' }}}">
 		<label class="control-label" for="first_name">First Name</label>

--- a/app/views/layouts/default.blade.php
+++ b/app/views/layouts/default.blade.php
@@ -20,7 +20,6 @@
 		<!-- CSS
 		================================================== -->
 		<link href="{{{ asset('assets/css/bootstrap.css') }}}" rel="stylesheet">
-		<link href="{{{ asset('assets/css/bootstrap-responsive.css') }}}" rel="stylesheet">
 
 		<style>
 		@section('styles')
@@ -29,6 +28,8 @@
 			}
 		@show
 		</style>
+
+		<link href="{{{ asset('assets/css/bootstrap-responsive.css') }}}" rel="stylesheet">
 
 		<!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
 		<!--[if lt IE 9]>


### PR DESCRIPTION
The bootstrap-responsive.css needed to be moved after the custom css block (the responsive nav/body padding was broken as both are embedded before the css customizations).  

I also fixed the .gitignore & .gitattribute files which had diff's commited in (likely from an overlooked conflict in the past).

Additionally, I've fixed the missing CSRF token cited in issue #14 
